### PR TITLE
tutorials: add tutorial for a robot with MicroPython/BBC micro:bit Kitronik All-in-one Robotics Board

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -367,6 +367,7 @@ Inspired by the [Awesome lists](https://github.com/sindresorhus/awesome).
 
 ## Tutorials
 
+* [micropython-microbit-kitronik-robotics](https://github.com/KitronikLtd/micropython-microbit-kitronik-robotics) - Example MicroPython (for BBC micro:bit) code for the Kitronik All-in-one Robotics Board.
 * [MicroPython NES Emulator on a RISC-V 64 Processor](https://robotzero.one/micropython-nes-emulator-on-a-risc-v-64-processor/) - Project executed in a FPGA.
 
 ## Resources


### PR DESCRIPTION
Proposed in #9 by @RDaneelOlivawBot (sent by Ivanhercaz in Telegram). Add a tutorial about how to develop a robot with MicroPython/BBC micro:bit Kitronik All-in-one Robotics Board.

This commit closes #9.